### PR TITLE
Reword 'Link Title in the catalog' setting's description.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 4chan XT uses a different user script namespace, so to migrate you need to export settings from 4chan X, and import them
 in XT.
 
+### Unreleased
+
+- Reworded 'Link Title in the catalog' setting's description.
+
 ### v2.3.5 (2023-01-09)
 
 - Fixed user poster IDs not appearing on new posts. [#20](https://github.com/TuxedoTako/4chan-xt/issues/20)

--- a/src/config/Config.js
+++ b/src/config/Config.js
@@ -164,8 +164,7 @@ const Config = {
       'Link Title in the catalog': [
         false,
         'Replace the link of a supported site with its actual title in the catalog too. ' +
-          'This is a separate settings because /vt/ had some many embeds it lagged Violentmonkey on chromium ' +
-          '<a href="https://github.com/ccd0/4chan-x/issues/3427" target="_blank" rel="noopener">(4chan-x#3427)</a>.',
+          'Speed up performance for boards that have many embeds (e.g /vt/) if turned off',
         2
       ],
       'Cover Preview': [


### PR DESCRIPTION
Since Violentmonkey has updated its extension and the issue is fixed, reword the setting's description.