### PR TITLE
Update CSS to remove older properties

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -34,9 +34,6 @@
   background-color: #F2F2F2;
   color: #888;
 }
-.field::-webkit-search-decoration {
-  display: none;
-}
 .move {
   cursor: move;
   overflow: hidden;
@@ -759,7 +756,6 @@ div[data-checked="false"] > .suboption-list {
   left: -1em;
   width: 0;
 }
-/* ``::-webkit-*'' selectors break selector lists on Firefox. */
 #index-search::-webkit-search-cancel-button {
   display: none;
 }

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -20,9 +20,8 @@
   outline: none;
   transition: color .25s, border-color .25s;
 }
-.field::-moz-placeholder {
+.field::placeholder {
   color: #AAA;
-  font-size: 13px;
   opacity: 1;
 }
 .field:hover {

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -1149,8 +1149,6 @@ textarea.copy-text-element {
   position: fixed;
 }
 :root.fixed-watcher #watched-threads {
-  /* XXX https://code.google.com/p/chromium/issues/detail?id=168840, https://bugs.webkit.org/show_bug.cgi?id=94158 */
-  max-height: 85vh;
   max-height: calc(100vh - 75px);
 }
 :root:not(.fixed-watcher) #watched-threads:not(:hover) {
@@ -1349,8 +1347,6 @@ textarea.copy-text-element {
   max-height: 100vh;
 }
 :root.fit-height.fixed .full-image {
-  /* XXX https://code.google.com/p/chromium/issues/detail?id=168840, https://bugs.webkit.org/show_bug.cgi?id=94158 */
-  max-height: 93vh;
   max-height: calc(100vh - 35px);
 }
 :root.fit-width .full-image {
@@ -1364,8 +1360,6 @@ textarea.copy-text-element {
 }
 #ihover {
   pointer-events: none;
-  /* XXX https://code.google.com/p/chromium/issues/detail?id=168840, https://bugs.webkit.org/show_bug.cgi?id=94158 */
-  max-height: 95vh;
   max-height: calc(100vh - 25px);
   max-width: 100vw;
 }
@@ -1591,8 +1585,6 @@ $site$thread[hidden] + hr {
   border-radius: 3px 3px 0 0;
 }
 #qr > form {
-  /* XXX https://code.google.com/p/chromium/issues/detail?id=168840, https://bugs.webkit.org/show_bug.cgi?id=94158 */
-  max-height: 85vh;
   max-height: calc(100vh - 75px);
   overflow-y: auto;
   overflow-x: hidden;
@@ -2281,8 +2273,6 @@ a:only-of-type > .remove {
 }
 .gal-fit-height .gal-image img,
 .gal-fit-height .gal-image video {
-  /* XXX https://code.google.com/p/chromium/issues/detail?id=168840, https://bugs.webkit.org/show_bug.cgi?id=94158 */
-  max-height: 95vh;
   max-height: calc(100vh - 25px);
 }
 .gal-image iframe {

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -84,8 +84,7 @@ body.hasDropDownNav{
   color: #789922;
 }
 :root.sw-yotsuba .fileText a {
-  unicode-bidi: -moz-isolate;
-  unicode-bidi: -webkit-isolate;
+  unicode-bidi: isolate;
 }
 :root.sw-yotsuba #g-recaptcha {
   min-height: 78px;

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -495,13 +495,11 @@ audio.controls-added {
   color: white;
 }
 .notification > .close {
+  font-size: 11px;
   padding: 7px;
   top: 0px;
   right: 5px;
   position: absolute;
-}
-.notification > .fa-times::before {
-  font-size: 11px !important;
 }
 .message {
   box-sizing: border-box;

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -322,11 +322,9 @@ audio.controls-added {
 }
 .fixed.top-header #header-bar.autohide:not(:hover) {
   margin-bottom: -1em;
-  -webkit-transform: translateY(-100%);
   transform: translateY(-100%);
 }
 .fixed.bottom-header #header-bar.autohide:not(:hover) {
-  -webkit-transform: translateY(100%);
   transform: translateY(100%);
 }
 #scroll-marker {
@@ -414,34 +412,26 @@ audio.controls-added {
 @media (min-width: 1300px) {
   :root.sw-yotsuba.fixed:not(.centered-links) #header-bar {
     white-space: nowrap;
-    display: -webkit-flex;
     display: flex;
-    -webkit-align-items: center;
     align-items: center;
   }
   :root.sw-yotsuba.fixed:not(.centered-links) #board-list {
-    -webkit-flex: auto;
     flex: auto;
   }
   :root.sw-yotsuba.fixed:not(.centered-links) #full-board-list {
-    display: -webkit-flex;
     display: flex;
   }
   :root.sw-yotsuba.fixed:not(.centered-links) .hide-board-list-container {
-    -webkit-flex: none;
     flex: none;
     margin-right: 5px;
   }
   :root.sw-yotsuba.fixed:not(.centered-links) #full-board-list > .boardList {
-    -webkit-flex: auto;
     flex: auto;
-    display: -webkit-flex;
     display: flex;
     width: 0px; /* XXX Fixes Edge not shrinking the board list below default size when needed */
   }
   :root.sw-yotsuba.fixed:not(.centered-links) #full-board-list > .boardList > a,
   :root.sw-yotsuba.fixed:not(.centered-links) #full-board-list > .boardList > span:not(.space):not(.spacer) {
-    -webkit-flex: none;
     flex: none;
     padding: .17em;
     margin: -.17em -.32em;
@@ -450,20 +440,15 @@ audio.controls-added {
     pointer-events: none;
   }
   :root.sw-yotsuba.fixed:not(.centered-links) #full-board-list > .boardList > span.space {
-    -webkit-flex: 0 .63 .63em;
     flex: 0 .63 .63em;
   }
   :root.sw-yotsuba.fixed:not(.centered-links) #full-board-list > .boardList > span.spacer {
-    -webkit-flex: 0 .38 .38em;
     flex: 0 .38 .38em;
   }
   :root.sw-yotsuba.fixed:not(.centered-links) #shortcuts {
     float: initial;
-    -webkit-flex: none;
     flex: none;
-    display: -webkit-flex;
     display: flex;
-    -webkit-align-items: center;
     align-items: center;
   }
 }
@@ -549,7 +534,6 @@ audio.controls-added {
 }
 #overlay {
   background-color: rgba(0, 0, 0, .5);
-  display: -webkit-flex;
   display: flex;
   top: 0;
   left: 0;
@@ -565,14 +549,11 @@ audio.controls-added {
   max-width: 100%;
   margin: auto;
   padding: 5px;
-  display: -webkit-flex;
   display: flex;
-  -webkit-flex-direction: column;
   flex-direction: column;
 }
 #fourchanx-settings > nav {
   padding: 2px 2px 8px;
-  display: -webkit-flex;
   display: flex;
 }
 #fourchanx-settings > nav a {
@@ -584,7 +565,6 @@ audio.controls-added {
   margin: 0;
 }
 .section-container {
-  -webkit-flex: 1;
   flex: 1;
   position: relative;
   overflow: auto;
@@ -592,7 +572,6 @@ audio.controls-added {
   overscroll-behavior: contain;
 }
 .sections-list {
-  -webkit-flex: 1;
   flex: 1;
 }
 .export, .import, .reset {
@@ -1007,17 +986,13 @@ div[data-checked="false"] > .suboption-list {
   text-align: left;
   white-space: nowrap;
   border-top: 1px solid transparent;
-  display: -webkit-flex;
   display: flex;
-  -webkit-flex-direction: row;
   flex-direction: row;
-  -webkit-align-items: stretch;
   align-items: stretch;
 }
 .catalog-reply > * {
   padding: 3px;
   overflow: hidden;
-  -webkit-flex: none;
   flex: none;
 }
 .catalog-reply > span {
@@ -1025,7 +1000,6 @@ div[data-checked="false"] > .suboption-list {
   font-weight: bold;
 }
 .catalog-reply-excerpt {
-  -webkit-flex: 1 1 auto;
   flex: 1 1 auto;
 }
 .catalog-post .prettyprinted {
@@ -1192,21 +1166,17 @@ textarea.copy-text-element {
 }
 #watched-threads .watcher-link {
   max-width: 250px;
-  display: -webkit-inline-flex;
   display: inline-flex;
-  -webkit-flex-direction: row;
   flex-direction: row;
 }
 #watched-threads .watcher-page,
 #watched-threads .watcher-unread {
-  -webkit-flex: 0 0 auto;
   flex: 0 0 auto;
   margin-right: 2px;
 }
 #watched-threads .watcher-title {
   overflow: hidden;
   text-overflow: ellipsis;
-  -webkit-flex: 0 1 auto;
   flex: 0 1 auto;
 }
 #watched-threads .watcher-title:not(:first-child) {
@@ -1664,13 +1634,10 @@ $site$thread[hidden] + hr {
 }
 .persona {
   width: 100%;
-  display: -webkit-flex;
   display: flex;
-  -webkit-flex-direction: row;
   flex-direction: row;
 }
 .persona .field {
-  -webkit-flex: 1;
   flex: 1;
   width: 0;
 }
@@ -1686,9 +1653,7 @@ body:not(.board_f) #qr select[name="filetag"],
   display: none;
 }
 .persona button {
-  -webkit-flex: 0 0 23px;
   flex: 0 0 23px;
-  -webkit-align-self: stretch;
   align-self: stretch;
   border: 1px solid #BBB;
   padding: 0;
@@ -1791,9 +1756,7 @@ input.field.tripped:not(:hover):not(:focus) {
 
 /* File Input, Submit Button, Oekaki */
 #file-n-submit, #qr .oekaki {
-  display: -webkit-flex;
   display: flex;
-  -webkit-align-items: stretch;
   align-items: stretch;
   height: 25px;
   margin-top: 1px;
@@ -1811,12 +1774,9 @@ input.field.tripped:not(:hover):not(:focus) {
   width: 25%;
 }
 #qr-filename-container {
-  -webkit-flex: 1 1 auto;
   flex: 1 1 auto;
   width: 0;
-  display: -webkit-flex;
   display: flex;
-  -webkit-align-items: center;
   align-items: center;
   position: relative;
   padding: 1px;
@@ -1832,7 +1792,6 @@ input#qr-filename {
 }
 #qr-no-file,
 .has-file #qr-filename {
-  -webkit-flex: 1 1 auto;
   flex: 1 1 auto;
   width: 0px; /* XXX Fixes filename not shrinking to allow space for buttons in Edge */
   display: inline-block;
@@ -1849,12 +1808,9 @@ input#qr-filename {
   display: none;
 }
 #qr .oekaki > label {
-  -webkit-flex: 1 1 auto;
   flex: 1 1 auto;
   width: 0;
-  display: -webkit-flex;
   display: flex;
-  -webkit-align-items: center;
   align-items: center;
   height: 100%;
 }
@@ -1862,7 +1818,6 @@ input#qr-filename {
   margin: 0 3px;
 }
 #qr .oekaki > label > input {
-  -webkit-flex: 1 1 auto;
   flex: 1 1 auto;
   width: 0;
   height: 100%;
@@ -1899,7 +1854,6 @@ input#qr-filename {
 
 /* Spoiler Checkbox, QR Icons */
 #qr-filename-container > label, #qr-filename-container > a {
-  -webkit-flex: none;
   flex: none;
   margin: 0;
   margin-right: 3px;
@@ -1975,9 +1929,7 @@ input[type="checkbox"]:checked ~ .checkbox-letter {
   min-height: 90px;
   max-width: 100%;
   min-width: 100%;
-  display: -webkit-flex;
   display: flex;
-  -webkit-flex-wrap: wrap;
   flex-wrap: wrap;
 }
 #dump-list:hover {
@@ -1995,11 +1947,9 @@ input[type="checkbox"]:checked ~ .checkbox-letter {
   overflow: hidden;
   position: relative;
   text-shadow: 0 0 2px #000;
-  -webkit-transition: opacity .25s ease-in-out, -webkit-transform .25s ease-in-out;
-  transition: opacity .25s ease-in-out, transform .25s ease-in-out, -webkit-transform .25s ease-in-out;
+  transition: opacity .25s ease-in-out, transform .25s ease-in-out;
   vertical-align: top;
   background-size: cover;
-  -webkit-flex: none;
   flex: none;
 }
 .qr-preview:hover,
@@ -2019,12 +1969,10 @@ input[type="checkbox"]:checked ~ .checkbox-letter {
 }
 .qr-preview.drag {
   box-shadow: 0 0 10px rgba(0,0,0,.5);
-  -webkit-transform: scale(.8);
   transform: scale(.8);
 }
 .qr-preview.over {
   border-color: #fff;
-  -webkit-transform: scale(1.1);
   transform: scale(1.1);
   opacity: 0.9;
   z-index: 10;
@@ -2065,12 +2013,10 @@ a:only-of-type > .remove {
   position: absolute;
   bottom: 20px;
   right: 10px;
-  -webkit-transform: translateY(-50%);
   transform: translateY(-50%);
 }
 .textarea {
   position: relative;
-  display: -webkit-flex;
   display: flex;
 }
 #char-count {
@@ -2206,11 +2152,9 @@ a:only-of-type > .remove {
   display: none;
 }
 #embedding > div:first-child {
-  display: -webkit-flex;
   display: flex;
 }
 #embedding .move {
-  -webkit-flex: 1;
   flex: 1;
 }
 #embedding .jump {
@@ -2225,32 +2169,22 @@ a:only-of-type > .remove {
   bottom: 0;
   left: 0;
   right: 0;
-  display: -webkit-flex;
   display: flex;
-  -webkit-flex-direction: row;
   flex-direction: row;
   background: rgba(0,0,0,0.7);
 }
 .gal-viewport {
-  display: -webkit-flex;
   display: flex;
-  -webkit-align-items: stretch;
   align-items: stretch;
-  -webkit-flex-direction: row;
   flex-direction: row;
-  -webkit-flex: 1 1 auto;
   flex: 1 1 auto;
   overflow: hidden;
 }
 .gal-thumbnails {
-  -webkit-flex: 0 0 150px;
   flex: 0 0 150px;
   overflow-y: auto;
-  display: -webkit-flex;
   display: flex;
-  -webkit-flex-direction: column;
   flex-direction: column;
-  -webkit-align-items: stretch;
   align-items: stretch;
   text-align: center;
   background: rgba(0,0,0,.5);
@@ -2267,7 +2201,6 @@ a:only-of-type > .remove {
   width: auto;
 }
 .gal-thumb {
-  -webkit-flex: 0 0 auto;
   flex: 0 0 auto;
   padding: 3px;
   line-height: 0;
@@ -2284,7 +2217,6 @@ a:only-of-type > .remove {
 }
 .gal-prev,
 .gal-next {
-  -webkit-flex: 0 0 20px;
   flex: 0 0 20px;
   position: relative;
   cursor: pointer;
@@ -2299,7 +2231,6 @@ a:only-of-type > .remove {
 .gal-next::after {
   position: absolute;
   top: 48.6%;
-  -webkit-transform: translateY(-50%);
   transform: translateY(-50%);
   display: inline-block;
   border-top: 11px solid transparent;
@@ -2315,13 +2246,9 @@ a:only-of-type > .remove {
   right: 3px;
 }
 .gal-image {
-  -webkit-flex: 1 0 auto;
   flex: 1 0 auto;
-  display: -webkit-flex;
   display: flex;
-  -webkit-align-items: flex-start;
   align-items: flex-start;
-  -webkit-justify-content: space-around;
   justify-content: space-around;
   overflow: hidden;
   /* Flex > Non-Flex child max-width and overflow fix (Firefox only?) */
@@ -2334,9 +2261,7 @@ a:only-of-type > .remove {
   overflow-x: scroll !important;
 }
 .gal-image a {
-  display: -webkit-flex;
   display: flex;
-  -webkit-align-items: flex-start;
   align-items: flex-start;
   margin: auto;
   line-height: 0;
@@ -2348,7 +2273,6 @@ a:only-of-type > .remove {
 }
 .gal-image img,
 .gal-image video {
-  -webkit-flex: none;
   flex: none;
 }
 .gal-fit-width .gal-image img,
@@ -2410,13 +2334,9 @@ a:only-of-type > .remove {
 .gal-labels {
   position: fixed;
   bottom: 6px;
-  display: -webkit-flex;
   display: flex;
-  -webkit-flex-direction: column;
   flex-direction: column;
-  -webkit-align-items: flex-end;
   align-items: flex-end;
-
 }
 :root:not(.show-sauce) .gal-sauce {
   display: none;

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -2012,7 +2012,7 @@ a:only-of-type > .remove {
 }
 
 /* Menu */
-.menu-button:not(.fa-bars) {
+.menu-button {
   display: inline-block;
   position: relative;
   cursor: pointer;
@@ -2359,8 +2359,7 @@ a:only-of-type > .remove {
 :root.gal-hide-thumbnails.gal-fit-height:not(.gal-pdf) .gal-labels {
   right: 28px !important;
 }
-:root.gallery-open.fixed #header-bar:not(.autohide),
-:root.gallery-open.fixed #header-bar:not(.autohide) #shortcuts .fa::before {
+:root.gallery-open.fixed #header-bar:not(.autohide) {
   visibility: hidden;
 }
 

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -355,12 +355,6 @@ audio.controls-added {
 #shortcuts:empty {
   display: none;
 }
-.brackets-wrap::before {
-  content: "\00a0[";
-}
-.brackets-wrap::after {
-  content: "]\00a0";
-}
 .dead-thread,
 .disabled:not(.replies-quoting-you) {
   opacity: .45;

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -15,7 +15,6 @@
 .field {
   background-color: #FFF;
   border: 1px solid #CCC;
-  -moz-box-sizing: border-box;
   box-sizing: border-box;
   color: #333;
   font: 13px sans-serif;
@@ -533,7 +532,6 @@ audio.controls-added {
   font-size: 11px !important;
 }
 .message {
-  -moz-box-sizing: border-box;
   box-sizing: border-box;
   padding: 6px 20px;
   max-height: 200px;
@@ -550,7 +548,6 @@ audio.controls-added {
 
 /* Settings */
 :root.fourchan-x body {
-  -moz-box-sizing: border-box;
   box-sizing: border-box;
 }
 #overlay {
@@ -563,7 +560,6 @@ audio.controls-added {
   width: 100%;
 }
 #fourchanx-settings {
-  -moz-box-sizing: border-box;
   box-sizing: border-box;
   box-shadow: 0 0 15px rgba(0, 0, 0, .15);
   height: 600px;
@@ -831,7 +827,6 @@ div[data-checked="false"] > .suboption-list {
 }
 .catalog-thread {
   display: inline-block;
-  -moz-box-sizing: border-box;
   box-sizing: border-box;
   border: 1px solid transparent;
   word-wrap: break-word;
@@ -1038,7 +1033,6 @@ div[data-checked="false"] > .suboption-list {
 }
 .catalog-post .prettyprinted {
   max-width: 100%;
-  -moz-box-sizing: border-box;
   box-sizing: border-box;
 }
 .catalog-post .MathJax_Display {
@@ -1735,7 +1729,6 @@ input.field.tripped:not(:hover):not(:focus) {
   resize: both;
 }
 .field {
-  -moz-box-sizing: border-box;
   box-sizing: border-box;
   margin: 0px;
   padding: 2px 4px 3px;
@@ -1995,7 +1988,6 @@ input[type="checkbox"]:checked ~ .checkbox-letter {
   overflow-x: auto;
 }
 .qr-preview {
-  -moz-box-sizing: border-box;
   box-sizing: border-box;
   counter-increment: thumbnails;
   cursor: move;

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -11,7 +11,6 @@
 #thread-watcher {
   box-shadow: -1px 2px 2px rgba(0, 0, 0, 0.25);
 }
-.captcha-img,
 .field {
   background-color: #FFF;
   border: 1px solid #CCC;
@@ -26,7 +25,6 @@
   font-size: 13px;
   opacity: 1;
 }
-.captch-img:hover,
 .field:hover {
   border-color: #999;
 }
@@ -1613,8 +1611,7 @@ $site$thread[hidden] + hr {
 }
 #qr select,
 #qr-filename-container > a,
-.remove,
-.captcha-img {
+.remove {
   cursor: pointer;
 }
 #qr {


### PR DESCRIPTION
Given the new `minVer` for XT is Chrome 80 and Firefox 74, a lot of these changes just remove legacy/older properties. Some of this stuff was unprefixed 10 years ago.

Might it break compatibility with the 2 people using legacy browsers? Maybe. They can add back what they need in the `Custom CSS`.

Future thoughts:
- Since Custom Properties are already being used, there is the possibility of getting all the CSS into 1 file.
```css
:root.yotsuba {
--main-background-color: #F0E0D6;
--main-border-color: #D9BFB7;
--input-border-color: #EA8;
--header-bar-background-color: rgba(240,224,214,0.98);
--header-bar-font-size: 9pt;
--header-bar-font-color: #B86;
--header-bar-link-color: #800000;
--backlink-deadlink-color: #00E;
--quote-color: #789922;
--inline-background-color: rgba(255, 255, 255, .14);
--qr-preview-background-color: rgba(0, 0, 0, .15);
--qr-link-background: linear-gradient(#FFEFE5, #F0E0D6) repeat scroll 0% 0% transparent;
--qr-link-background-hover: #F0E0D6;
--qr-link-border-color: rgb(225, 209, 199) rgb(225, 209, 199) rgb(210, 194, 184);
--menu-font-color: #800000;
--menu-font-size: 10pt;
--menu-entry-focused-background: rgba(255, 255, 255, .33);
--unread-background-color: rgba(240,224,214,0.5);
--unread-line-color: rgb(255,0,0);
--quoting-you-color: #F00;
--watch-thread-link: url("data:image/svg+xml,<svg viewBox='0 0 26 26' preserveAspectRatio='true' xmlns='http://www.w3.org/2000/svg'><path fill='rgb(128,0,0)' d='M24.132,7.971c-2.203-2.205-5.916-2.098-8.25,0.235L15.5,8.588l-0.382-0.382c-2.334-2.333-6.047-2.44-8.25-0.235c-2.204,2.203-2.098,5.916,0.235,8.249l8.396,8.396l8.396-8.396C26.229,13.887,26.336,10.174,24.132,7.971z'/></svg>");
}
.dialog {
border: 1px solid var(--main-border-color);
display: block;
background-color: var(--main-background-color);
}
.inline {
border: 1px solid var(--main-border-color);
background-color: var(--inline-background-color);
display: table;
margin: 2px 0;
}
```

- If `minVer` was bumped to Chrome 88 and Firefox 78, that would allow the use of `:is()`, which could shave off some more lines here and there