### PR TITLE
Right-align shortcut icons in header when centered

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -286,6 +286,7 @@ audio.controls-added {
 :root.centered-links #shortcuts {
   width: 300px;
   text-align: right;
+  justify-content: right;
 }
 :root.centered-links #header-bar {
   text-align: center;


### PR DESCRIPTION
As of the last update the shortcut icons would now be left-aligned if using the centered header links option, which added a ton of whitespace to the right. This is just a quick one-line CSS fix for that.