### PR TITLE
Add Remember QR Size in Webkit

### DIFF
--- a/src/General/Settings.tsx
+++ b/src/General/Settings.tsx
@@ -245,9 +245,6 @@ Enable it on boards.${location.hostname.split('.')[1]}.org in your browser's pri
     addCheckboxes($('div[data-name="JSON Index"] > .suboption-list', section), Config.Index);
 
     // Unsupported options
-    if ($.engine !== 'gecko') {
-      $('div[data-name="Remember QR Size"]', section).hidden = true;
-    }
     if ($.perProtocolSettings || (location.protocol !== 'https:')) {
       $('div[data-name="Redirect to HTTPS"]', section).hidden = true;
     }

--- a/src/Posting/QR.ts
+++ b/src/Posting/QR.ts
@@ -802,8 +802,7 @@ var QR = {
       $.on(nodes[name], event, save);
     }
 
-    // XXX Blink and WebKit treat width and height of <textarea>s as min-width and min-height
-    if (($.engine === 'gecko') && Conf['Remember QR Size']) {
+    if (Conf['Remember QR Size']) {
       $.get('QR Size', '', item => nodes.com.style.cssText = item['QR Size']);
       $.on(nodes.com, 'mouseup', function(e) {
         if (e.button !== 0) { return; }


### PR DESCRIPTION
I'm pretty sure this was Gecko only due to a bug, but that bug (at least in my testing) must have been fixed within the last 10 years of the original implementation.