### PR TITLE
Address wobbly spin animation

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -2376,7 +2376,7 @@ a:only-of-type > .remove {
   100% {transform:rotate(359deg);}
 }
 
-.spin {
+.spin > .icon {
   animation:spin 2s infinite linear;
 }
 


### PR DESCRIPTION
Due to the parent element not being a square, the `.spin` class and subsequent animation was causing the refresh icon to not pivot correctly. Making the icon of the parent spin instead fixes this. This change also means the refresh/"check thread" icon in the Thread Watcher now turns instead of remaining stationery. Closes #64