### PR TITLE
Switch menu-button to FA icon

### DIFF
--- a/src/Icons/icon.ts
+++ b/src/Icons/icon.ts
@@ -17,6 +17,7 @@ import { svgPathData as downloadSvg, width as downloadW, height as downloadH } f
 import { svgPathData as bookOpenSvg, width as bookOpenW, height as bookOpenH } from "@fas/faBookOpen";
 import { svgPathData as shrinkSvg, width as shrinkW, height as shrinkH } from "@fas/faDownLeftAndUpRightToCenter";
 import { svgPathData as heartSvg, width as heartW, height as heartH } from "@fas/faHeart";
+import { svgPathData as caretDownSvg, width as caretDownW, height as caretDownH } from "@fas/faCaretDown";
 
 
 const toSvg = (svgPathData: string, width: string | number, height: string | number) => {
@@ -41,7 +42,8 @@ const icons = {
    download:  toSvg(downloadSvg, downloadW, downloadH),
    bookOpen:  toSvg(bookOpenSvg, bookOpenW, bookOpenH),
    shrink:    toSvg(shrinkSvg, shrinkW, shrinkH),
-   heart:     toSvg(heartSvg, heartW, heartH)
+   heart:     toSvg(heartSvg, heartW, heartH),
+   caretDown: toSvg(caretDownSvg, caretDownW, caretDownH)
 } as const;
 
 var Icon = {

--- a/src/Menu/Menu.js
+++ b/src/Menu/Menu.js
@@ -2,7 +2,7 @@ import Callbacks from "../classes/Callbacks";
 import UI from "../General/UI";
 import { g, Conf } from "../globals/globals";
 import $ from "../platform/$";
-import Iocn from "../Icons/icon";
+import Icon from "../Icons/icon";
 
 /*
  * decaffeinate suggestions:

--- a/src/Menu/Menu.js
+++ b/src/Menu/Menu.js
@@ -2,6 +2,7 @@ import Callbacks from "../classes/Callbacks";
 import UI from "../General/UI";
 import { g, Conf } from "../globals/globals";
 import $ from "../platform/$";
+import Iocn from "../Icons/icon";
 
 /*
  * decaffeinate suggestions:
@@ -18,7 +19,7 @@ var Menu = {
     }
     );
 
-    $.extend(this.button, {textContent: "🞃"});
+    Icon.set(this.button, 'caretDown');
 
     this.menu = new UI.Menu('post');
     Callbacks.Post.push({

--- a/src/Monitoring/ThreadWatcher.js
+++ b/src/Monitoring/ThreadWatcher.js
@@ -45,13 +45,16 @@ var ThreadWatcher = {
     this.db     = new DataBoard('watchedThreads', this.refresh, true);
     this.dbLM   = new DataBoard('watcherLastModified', null, true);
     this.dialog = UI.dialog('thread-watcher', { innerHTML: ThreadWatcherPage });
-    Icon.set(this.dialog.firstElementChild.firstElementChild, 'refresh');
     this.status = $('#watcher-status', this.dialog);
     this.list   = this.dialog.lastElementChild;
     this.refreshButton = $('.refresh', this.dialog);
+    this.menuButton = $('.menu-button', this.dialog);
     this.closeButton = $('.move > .close', this.dialog);
     this.unreaddb = Unread.db || UnreadIndex.db || new DataBoard('lastReadPosts');
     this.unreadEnabled = Conf['Remember Last Read Post'];
+
+    Icon.set(this.refreshButton, 'refresh');
+    Icon.set(this.menuButton, 'caretDown');
 
     $.on(d, 'QRPostSuccessful',   this.cb.post);
     $.on(sc, 'click', this.toggleWatcher);

--- a/src/Monitoring/ThreadWatcher/ThreadWatcher.html
+++ b/src/Monitoring/ThreadWatcher/ThreadWatcher.html
@@ -1,7 +1,7 @@
 <div class="move">
-  Thread Watcher <a class="refresh" title="Check threads" href="javascript:;" title="refresh">🗘</a>
+  Thread Watcher <a class="refresh" title="Check threads" href="javascript:;" title="refresh"></a>
   <span id="watcher-status"></span>
-  <a class="menu-button" href="javascript:;">🞃</a>
+  <a class="menu-button" href="javascript:;"></a>
   <a class="close" href="javascript:;">×</a>
 </div>
 <div id="watched-threads"></div>

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -878,11 +878,8 @@ div[data-checked="false"] > .suboption-list {
   vertical-align: text-top;
   padding-left: 2px;
 }
-.catalog-stats > .menu-button {
-  font-weight: normal;
-}
-.catalog-stats > .menu-button > i::before {
-  line-height: 11px;
+.catalog-stats > .menu-button > svg.icon {
+  height: 10px;
 }
 .catalog-stats {
   font-size: 10px;
@@ -2008,11 +2005,8 @@ a:only-of-type > .remove {
   margin: 2px;
   vertical-align: middle;
 }
-.postInfo > .menu-button,
-#thread-watcher .menu-button {
-  width: 18px;
-  height: 15px;
-  text-align: center;
+.postInfo > .menu-button {
+  margin: 0 5px;
 }
 #menu {
   position: fixed;


### PR DESCRIPTION
Switches the `🞃` used for `menu-button` to its Font Awesome icon equivalent, `caret-down`, as `🞃` does not render on macOS/iOS. I should note that 4chan X used `chevron-down`/`angle-down` - so up to you if you want to switch to that.

This would count as a continuation of #38, and also fixes some of the poor alignment with CSS.
For reference, here's what it looks like:
![image](https://github.com/TuxedoTako/4chan-xt/assets/877480/cfd64bae-5ec6-4054-a8ec-46e736422c51)

Not sure if switching all the other icons (e.g. close unicode icons, CSS icons in the gallery and menu icon in the header) to the FA icons is something you'd be interested in @TuxedoTako, [as per my original PR on 4chan X](https://github.com/ccd0/4chan-x/pull/2395).