### PR TITLE
YouTube fix

### DIFF
--- a/src/Linkification/Embedding.tsx
+++ b/src/Linkification/Embedding.tsx
@@ -672,7 +672,7 @@ var Embedding = {
     }
     , {
       key: 'YouTube',
-      regExp: /^\w+:\/\/(?:youtu.be\/|[\w.]*youtube[\w.]*\/.*(?:v=|\bembed\/|\bv\/|shorts\/|live\/))([\w\-]{11})(.*)/,
+      regExp: /^\w+:\/\/(?:youtu.be\/|[\w.]*youtube[\w.]*\/.*(?:v=|\bembed\/|\bv\/|shorts\/|live\/|watch\/))([\w\-]{11})(.*)/,
       el(a) {
         let start = a.dataset.options.match(/\b(?:star)?t\=(\w+)/);
         if (start) { start = start[1]; }


### PR DESCRIPTION
* Handle the case of a Youtube URL formatted using `/watch/` without any `?v=` parameter
   - See this post for an example https://archive.palanq.win/vt/thread/78985087/#78987646