### PR TITLE
Ignore "Randomize Filename" if it's a soundpost

### DIFF
--- a/src/Posting/QR.ts
+++ b/src/Posting/QR.ts
@@ -2163,7 +2163,7 @@ class post {
 
       this.file = await this.validateFile(file);
       this.originalName = file.name;
-      if (Conf['Randomize Filename'] && (g.BOARD.ID !== 'f')) {
+      if (Conf['Randomize Filename'] && (g.BOARD.ID !== 'f') && (!this.file.name.includes('[sound='))) {
         this.randomizeName(false);
       } else {
         this.filename = this.file.name;


### PR DESCRIPTION
This change will ignore the "Randomize Filename" config if the file's name includes `[sound=`.
This will prevent soundposts from accidentally breaking but keep the option working for any other posts.

There was a discussion about it on /vt/ and someone shared their workaround: https://warosu.org/vt/thread/81247253#p81248725
That solution would only work for webm, but there are soundposts with images too, so I'm not including that bit.