### PR TITLE
Allow custom header positioning

### DIFF
--- a/src/General/Header.ts
+++ b/src/General/Header.ts
@@ -207,9 +207,24 @@ var Header = {
     $.rmAll(list);
     if (!boardnav) { return; }
     boardnav = boardnav.replace(/(\r\n|\n|\r)/g, ' ');
-    const re = /[\w@]+(-(all|title|replace|full|index|catalog|archive|expired|nt|(mode|sort|text):"[^"]+"(,"[^"]+")?))*|[^\w@]+/g;
-    const nodes = (boardnav.match(re).map((t) => Header.mapCustomNavigation(t)));
-    $.add(list, nodes);
+    const segments = boardnav.split(/(\{\{|\}\})/);
+    const spanStack = [];
+    let currentContainer = list;
+    segments.forEach(segment => {
+      if (segment === '{{') {
+        const span = $.el('span');
+        $.add(currentContainer, span);
+        spanStack.push(span);
+        currentContainer = span;
+      } else if (segment === '}}') {
+        spanStack.pop();
+        currentContainer = spanStack.length > 0 ? spanStack[spanStack.length - 1] : list;
+      } else {
+        const re = /[\w@]+(-(all|title|replace|full|index|catalog|archive|expired|nt|(mode|sort|text):"[^"]+"(,"[^"]+")?))*|[^\w@]+/g;
+        const segmentNodes = (segment.match(re) || []).map((t) => Header.mapCustomNavigation(t));
+        segmentNodes.forEach(node => currentContainer.appendChild(node));
+      }
+    });
     return CatalogLinks.setLinks(list);
   },
 
@@ -291,6 +306,7 @@ var Header = {
         return $.el('a', {
           href: 'https://twitter.com/4chan',
           title: '4chan Twitter',
+          className: 'navSmall',
           textContent: '@'
         }
         );
@@ -355,7 +371,6 @@ var Header = {
       a.rel = 'noopener';
     }
 
-    if (boardID === '@') { $.addClass(a, 'navSmall'); }
     return a;
   },
 


### PR DESCRIPTION
This potentially closes a [long standing feature request](https://github.com/ccd0/4chan-x/issues/104), which creates `span` elements when a `{{` is encountered when generating the Custom Navigation. Users can then use Custom CSS to change these however they'd like, using `nth-child`, `flex` or `grid`, etc.

ChatGPT told me what to do, I copied it into VS Code, built, and tested it. `a{{a{{b}}}}` seems to work, outputting `<span id="custom-board-list"><a href="//boards.4chan.org/a/" title="Anime &amp; Manga">a</a><span><a href="//boards.4chan.org/a/" title="Anime &amp; Manga">a</a><span><a href="//boards.4chan.org/b/" title="Random">b</a></span></span></span>`. Couldn't understand how to create a branch/pull request in VS Code, so I came back to the browser to do this part.

If you can see how the code can be improved, by all means change it. While I was there I also made `@` get the `navSmall` class when it's being handled earlier.

I'd imagine another improvement could be the addition of `nolink` or some variant, because at the moment any text is converted to a broken-linked `a` tag (i.e. `the` becomes `<a href="//boards.4chan.org/the/" title="">the</a>`). `nolink-text:"the"` creates a text node, or perhaps a span with the class `nolink` for easier styling, and might still be able to follow the rest of the formatting options. `nolink-current-title` creates `Technology`. Or I guess, if it doesn't find that combination of letters matches a board, it has nothing to convert, and so just converts it to text anyway. But, that's a problem for another day.