### PR TITLE
Add anonymous: true to cross-origin gmOptions

### DIFF
--- a/src/platform/CrossOrigin.ts
+++ b/src/platform/CrossOrigin.ts
@@ -51,6 +51,7 @@ var CrossOrigin = {
       }
       const gmOptions = {
         method: "GET",
+        anonymous: true,
         url,
         headers,
         responseType: 'arraybuffer',
@@ -165,6 +166,7 @@ var CrossOrigin = {
 
       const gmOptions = {
         method: 'GET',
+        anonymous: true,
         url,
         headers,
         timeout,


### PR DESCRIPTION
This fixes requests failing when first-party isolation is enabled on Firefox. This does mean site cookies will not be sent by default in those requests, but (I'm pretty sure) no usages of these methods need them anyway, so it's fine. Worst case scenario, the respective functions could have an optional parameter to control this behavior.