### PR TITLE
Add discernible classes and names to stubs

### DIFF
--- a/src/Filtering/PostHiding.ts
+++ b/src/Filtering/PostHiding.ts
@@ -272,6 +272,7 @@ var PostHiding = {
 
   makeButton(post, type) {
     const span = $.el('span', {
+      className: 'stub-icon',
       textContent: type === 'hide' ? '➖︎' : '➕︎',
     });
     const a = $.el('a', {
@@ -340,7 +341,7 @@ var PostHiding = {
 
     post.nodes.stub = $.el('div', { className: 'stub' });
     const a = PostHiding.makeButton(post, 'show');
-    $.add(a, $.tn(` ${post.info.nameBlock}`));
+    $.add(a, $.el('span', { className: 'stub-name', textContent: post.info.nameBlock}));
 
     let reasons = post.filterResults?.reasons || [];
     if (reason) reasons = [...reasons, reason];

--- a/src/Filtering/ThreadHiding.js
+++ b/src/Filtering/ThreadHiding.js
@@ -199,7 +199,7 @@ var ThreadHiding = {
       className: `${type}-thread-button`,
       href:      'javascript:;'
     });
-    $.add(a, $.el('span', { textContent: type === 'hide' ? '➖︎' : '➕︎' }));
+    $.add(a, $.el('span', { className: 'stub-icon', textContent: type === 'hide' ? '➖︎' : '➕︎' }));
     a.dataset.fullID = thread.fullID;
     $.on(a, 'click', ThreadHiding.toggle);
     return a;
@@ -212,9 +212,7 @@ var ThreadHiding = {
 
     const a = ThreadHiding.makeButton(thread, 'show');
     const { nameBlock, subject } = thread.OP.info;
-    $.add(a, $.tn(
-      ` ${subject ? subject + ' - ' : ''}${nameBlock} (${numReplies} repl${numReplies === 1 ? 'y' : 'ies'})`
-    ));
+    a.innerHTML = `${subject ? `<span class="stub-subject">${subject}</span>` : ''}<span class="stub-name">${nameBlock}</span><span class="stub-replies">(${numReplies} repl${numReplies === 1 ? 'y' : 'ies'})</span>`;
 
     let reasons = thread.OP.filterResults?.reasons || [];
     if (reason) reasons = [...reasons, reason];

--- a/src/Filtering/ThreadHiding.js
+++ b/src/Filtering/ThreadHiding.js
@@ -212,8 +212,22 @@ var ThreadHiding = {
 
     const a = ThreadHiding.makeButton(thread, 'show');
     const { nameBlock, subject } = thread.OP.info;
-    a.innerHTML = `${subject ? `<span class="stub-subject">${subject}</span>` : ''}<span class="stub-name">${nameBlock}</span><span class="stub-replies">(${numReplies} repl${numReplies === 1 ? 'y' : 'ies'})</span>`;
-
+    
+    if (subject) {
+      $.add(a, $.el('span', {
+        className: 'stub-subject',
+        textContent: subject
+      }))
+    }
+    $.add(a, $.el('span', {
+      className: 'stub-name',
+      textContent: nameBlock
+    }))
+    $.add(a, $.el('span', {
+      className: 'stub-replies',
+      textContent: `(${numReplies} repl${numReplies === 1 ? 'y' : 'ies'})`
+    }))
+    
     let reasons = thread.OP.filterResults?.reasons || [];
     if (reason) reasons = [...reasons, reason];
 

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -1487,6 +1487,13 @@ $site$infoRoot a.hide-reply-button {
 .stub input {
   display: inline-block;
 }
+.stub-icon,
+.stub-subject {
+  margin-right: 1ch;
+}
+.stub-replies {
+  margin-left: 1ch;
+}
 .stub-reasons::before { content: ' ('; }
 .stub-reasons::after { content: ')'; }
 .stub-reason:not(:last-of-type)::after { content: ' & '; }


### PR DESCRIPTION
Following my comment from #108, I attempted a PR.

I'm sure there is a better way to make the HTML than `innerHTML`, but it's a start.