### PR TITLE
Reimplements split post functionality

### DIFF
--- a/src/Icons/icon.ts
+++ b/src/Icons/icon.ts
@@ -18,6 +18,7 @@ import { svgPathData as bookOpenSvg, width as bookOpenW, height as bookOpenH } f
 import { svgPathData as shrinkSvg, width as shrinkW, height as shrinkH } from "@fas/faDownLeftAndUpRightToCenter";
 import { svgPathData as heartSvg, width as heartW, height as heartH } from "@fas/faHeart";
 import { svgPathData as caretDownSvg, width as caretDownW, height as caretDownH } from "@fas/faCaretDown";
+import { svgPathData as scissorsSvg, width as scissorsW, height as scissorsH } from "@fas/faScissors";
 
 
 const toSvg = (svgPathData: string, width: string | number, height: string | number) => {
@@ -43,7 +44,8 @@ const icons = {
    bookOpen:  toSvg(bookOpenSvg, bookOpenW, bookOpenH),
    shrink:    toSvg(shrinkSvg, shrinkW, shrinkH),
    heart:     toSvg(heartSvg, heartW, heartH),
-   caretDown: toSvg(caretDownSvg, caretDownW, caretDownH)
+   caretDown: toSvg(caretDownSvg, caretDownW, caretDownH),
+   scissors:  toSvg(scissorsSvg, scissorsW, scissorsH)
 } as const;
 
 var Icon = {

--- a/src/Posting/QR.ts
+++ b/src/Posting/QR.ts
@@ -87,6 +87,7 @@ var QR = {
     fileInput: HTMLInputElement,
     flag?: HTMLSelectElement,
     preview?: HTMLDivElement;
+    splitPost?: HTMLAnchorElement;
   },
   shortcut: undefined as HTMLAnchorElement,
   hasFocus: false,
@@ -522,9 +523,50 @@ var QR = {
   characterCount() {
     const counter = QR.nodes.charCount;
     const count   = QR.nodes.com.value.replace(/[\uD800-\uDBFF][\uDC00-\uDFFF]/g, '_').length;
-    counter.textContent = count;
+    counter.textContent = count.toString();
     counter.hidden      = count < (QR.max_comment/2);
+
+    const splitPost = QR.nodes.splitPost;
+    splitPost.hidden = count < QR.max_comment;
+
     return (count > QR.max_comment ? $.addClass : $.rmClass)(counter, 'warning');
+  },
+
+  splitPost() {
+    if (QR.selected.isLocked) return;
+    const count = QR.nodes.com.value.replace(/[\uD800-\uDBFF][\uDC00-\uDFFF]/g, '_').length;
+    if (count < QR.max_comment) return;
+    const text = QR.nodes.com.value;
+    let lastPostLength = 0;
+    let splitCount = 0;
+    const idx = QR.posts.indexOf(QR.selected);
+    QR.selected.setComment("");
+
+    for (const line of text.split("\n")) {
+      const currentLength = line.replace(/[\uD800-\uDBFF][\uDC00-\uDFFF]/g, '_').length + 1 // +1 for newline at end
+      if (currentLength + lastPostLength > QR.max_comment) {
+        const post = new QR.post(true);
+        post.setComment(line);
+        lastPostLength = currentLength;
+        splitCount++;
+      } else {
+        const newComment = [QR.selected.com, line].filter(el => el !== null).join('\n');
+        QR.selected.setComment(newComment);
+        lastPostLength += currentLength;
+      }
+    }
+    const newPostIdx = QR.posts.length - splitCount;
+    const newPosts = QR.posts.splice(newPostIdx, splitCount)
+    QR.posts.splice(idx + 1, 0, ...newPosts);
+    const rearrangedDumpList = [...QR.nodes.dumpList.children];
+    const newDumps = rearrangedDumpList.splice(newPostIdx, splitCount);
+    rearrangedDumpList.splice(idx + 1, 0, ...newDumps);
+
+    for (const e of rearrangedDumpList) {
+      QR.nodes.dumpList.appendChild(e);
+    }
+
+    QR.nodes.el.classList.add('dump');
   },
 
   getFile() {
@@ -751,6 +793,7 @@ var QR = {
     setNode('status',         '[type=submit]');
     setNode('flashTag',       '[name=filetag]');
     setNode('fileInput',      '[type=file]');
+    setNode('splitPost',      '#split-post')
 
     const {config} = g.BOARD;
     const {classList} = QR.nodes.el;
@@ -795,6 +838,7 @@ var QR = {
     $.on(nodes.customCooldown, 'click',     QR.toggleCustomCooldown);
     $.on(nodes.dumpButton,     'click',     () => nodes.el.classList.toggle('dump'));
     $.on(nodes.fileInput,      'change',    QR.handleFiles);
+    $.on(nodes.splitPost,      'click',     QR.splitPost);
 
     window.addEventListener('focus', QR.focus, true);
     window.addEventListener('blur',  QR.focus, true);
@@ -850,6 +894,7 @@ var QR = {
     Icon.set(nodes.compress, 'shrink');
     Icon.set(nodes.view, 'eye');
     Icon.set(nodes.restoreNameButton, 'undo');
+    Icon.set(nodes.splitPost, 'scissors');
   },
 
   flags() {

--- a/src/Posting/QR/QuickReply.html
+++ b/src/Posting/QR/QuickReply.html
@@ -54,6 +54,7 @@
         <a href="javascript:;" id="url-button" title="Post from URL">🔗︎</a>
         <a href="javascript:;" hidden id="paste-area" title="Select to paste images" tabindex="-1" contentEditable="true">📋︎</a>
         <a href="javascript:;" id="custom-cooldown-button" title="Toggle custom cooldown" class="disabled">🕒︎</a>
+        <a href="javascript:;" id="split-post" title="Split into multiple posts" hidden>✂️</a>
         <a href="javascript:;" id="dump-button" title="Dump list">➕︎</a>
       </span>
       <input type="submit">

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -1860,7 +1860,7 @@ input[type="checkbox"]:checked ~ .checkbox-letter {
   opacity: 0;
   pointer-events: none;
 }
-.checkbox-letter, #paste-area, #url-button, #custom-cooldown-button, #dump-button {
+.checkbox-letter, #paste-area, #url-button, #custom-cooldown-button, #dump-button, #split-post {
   opacity: 0.6;
 }
 #paste-area {


### PR DESCRIPTION
Reimplements the split post functionality I originally coded up for 4ChanX in https://github.com/ccd0/4chan-x/pull/2928.

Additionally implements some of the changes ccd0 suggested, such as not assuming its at the end of the dump list, and bailing out if posting isLocked.

Finally, it has some logic so if you split a post in the _middle_ of the dumplist, it puts the split posts sequentially in the middle, rather than the new ones at the end.

Some videos of it in action:

Basic functionality:


https://github.com/user-attachments/assets/b8ec75b0-0b02-4dc6-840b-e9846c2a8a75

Keeping place in the dumplist

https://github.com/user-attachments/assets/4a020238-1b27-4608-85d9-67cc4bb775ee

