### PR TITLE
Tweak stub-icon CSS

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -1487,7 +1487,7 @@ $site$infoRoot a.hide-reply-button {
 .stub input {
   display: inline-block;
 }
-.stub-icon,
+.stub .stub-icon,
 .stub-subject {
   margin-right: 1ch;
 }


### PR DESCRIPTION
All posts were shifted `1ch` to the right when discernible class names were added to stubs, this adds some specificity to the selector to fix it