### PR TITLE
Update Twitter embed regex

### DIFF
--- a/src/Linkification/Embedding.tsx
+++ b/src/Linkification/Embedding.tsx
@@ -588,7 +588,7 @@ var Embedding = {
     }
     , {
       key: 'Twitter',
-      regExp: /^\w+:\/\/(?:www\.|mobile\.)?(?:twitter|x)\.com\/(\w+\/status\/\d+)/,
+      regExp: /^\w+:\/\/(?:www\.|mobile\.)?(?:(?:fx|vx)?twitter|(?:fixup|fixv)?x|twittpr)\.com\/(\w+\/status\/\d+)/,
       style: 'border: none; width: 550px; height: 250px; overflow: hidden; resize: both;',
       el(a) {
         if (Conf.XEmbedder === 'tf') {


### PR DESCRIPTION
Extend embed support for X embed service links: 
* FxTwitter
  1. fxtwitter.com
  2. fixupx.com
  3. twittpr.com 
* VxTwitter 
  1. vxtwitter.com
  2. fixvx.com

example: https://boards.4chan.org/vt/thread/89081711#p89086757