### PR TITLE
Remove `keyboard-focus` related code

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -56,9 +56,6 @@ a[href="javascript:;"] {
 body.hasDropDownNav{
   margin-top: 5px;
 }
-:root:not(.keyboard-focus) a {
-  outline: none;
-}
 .painted {
   border-radius: 3px;
   padding: 0px 2px;

--- a/src/main/Main.js
+++ b/src/main/Main.js
@@ -378,11 +378,6 @@ var Main = {
     $.addStyle(CSS.sub(CSS.boards), 'fourchanx-css');
     Main.bgColorStyle = $.el('style', {id: 'fourchanx-bgcolor-css'});
 
-    let keyboard = false;
-    $.on(d, 'mousedown', () => keyboard = false);
-    $.on(d, 'keydown', function(e) { if (e.keyCode === 9) { return keyboard = true; } }); // tab
-    window.addEventListener('focus', (() => doc.classList.toggle('keyboard-focus', keyboard)), true);
-
     return Main.setClass();
   },
 


### PR DESCRIPTION
The function in `Main` was essentially detecting if a user was using a keyboard to navigate the page, and then not applying an `outline` to anchor elements.

`:focus-visible` is the way to do this natively [[1]](https://developer.mozilla.org/en-US/docs/Web/CSS/:focus-visible), and I'm pretty sure it's the new default CSS in Chrome and Firefox's user agent CSS.

Technically, too advanced for the `minVer` of Firefox (v74) as this became unprefixed in v85 (Released 2021-01-26) but I'm not willing to find a version that old to test/care about.