### PR TITLE
Randomize checksum

### DIFF
--- a/src/Posting/QR.ts
+++ b/src/Posting/QR.ts
@@ -75,6 +75,7 @@ var QR = {
     oekakiButton: HTMLAnchorElement,
     randomizeButton: HTMLAnchorElement,
     compress: HTMLAnchorElement,
+    changeChecksum: HTMLAnchorElement,
     view: HTMLAnchorElement,
     restoreNameButton: HTMLAnchorElement,
     fileRM: HTMLAnchorElement,
@@ -778,6 +779,7 @@ var QR = {
     setNode('oekaki',         '.oekaki');
     setNode('drawButton',     '#qr-draw-button');
     setNode('randomizeButton','#qr-randomize');
+    setNode('changeChecksum','#qr-checksum');
     setNode('compress',       '#qr-jpg');
     setNode('view',           '#qr-view');
     setNode('restoreNameButton','#qr-restore-name');
@@ -828,6 +830,7 @@ var QR = {
     $.on(nodes.fileButton,     'click',     QR.openFileInput);
     $.on(nodes.noFile,         'click',     QR.openFileInput);
     $.on(nodes.randomizeButton,'click',     () => { QR.selected.randomizeName(); });
+    $.on(nodes.changeChecksum, 'click',     async () => { QR.selected.randomizeChecksum(true); await this.setFile(this.file);});
     $.on(nodes.compress,       'click',     async () => { QR.handleFiles([await QR.convert(QR.selected.file)]); });
     $.on(nodes.view,           'click',     QR.preview);
     $.on(nodes.restoreNameButton,'click',   () => { QR.selected.restoreName(); });
@@ -893,6 +896,7 @@ var QR = {
     Icon.set(nodes.pasteArea, 'clipboard');
     Icon.set(nodes.customCooldown, 'clock');
     Icon.set(nodes.randomizeButton, 'shuffle');
+    Icon.set(nodes.changeChecksum, 'image');
     Icon.set(nodes.compress, 'shrink');
     Icon.set(nodes.view, 'eye');
     Icon.set(nodes.restoreNameButton, 'undo');
@@ -2138,7 +2142,10 @@ class post {
       this.file = file;
       this.filename = file.name;
       this.originalName = file.name;
-
+      // Validate after changing checksum in case size changes
+      if (Conf['Randomize Checksum'] && this.file.type.startsWith('image/') && this.file.type !== 'image/gif') {
+        await this.randomizeChecksum(false);
+      }
       this.file = await this.validateFile(file);
       this.originalName = file.name;
       if (Conf['Randomize Filename'] && (g.BOARD.ID !== 'f') && (!this.file.name.toLowerCase().includes('[sound='))) {
@@ -2181,6 +2188,42 @@ class post {
 
   restoreName() {
     QR.nodes.filename.value = this.filename = this.originalName;
+  }
+
+  //Checksum randomization method inspired by KurobaEX
+  async randomizeChecksum(setThumbnail = true) {
+    const img = await createImageBitmap(this.file);
+    const canvas = document.createElement('canvas');
+    canvas.width = img.width;
+    canvas.height = img.height;
+    const ctx = canvas.getContext('2d');
+    ctx.drawImage(img, 0, 0);
+    
+    const imageData = ctx.getImageData(0, 0, canvas.width, canvas.height);
+    const data = imageData.data;
+    
+    // Pick one random pixel
+    const randomX = Math.floor(Math.random() * canvas.width);
+    const randomY = Math.floor(Math.random() * canvas.height);
+    const i = (randomY * canvas.width + randomX) * 4;
+    
+    // Modify it by a large enough amount to survive JPEG compression
+    const PIXEL_DIFF = 5;
+    for (let channel = 0; channel < 3; channel++) {
+      data[i + channel] = data[i + channel] >= 128 ? 
+        data[i + channel] - PIXEL_DIFF : 
+        data[i + channel] + PIXEL_DIFF;
+    }
+    
+    ctx.putImageData(imageData, 0, 0);
+    
+    const blob = await new Promise(resolve => 
+      canvas.toBlob(resolve, this.file.type, 1.0)
+    );
+    
+    this.file = new File([blob], this.file.name, { type: this.file.type });
+
+    if (setThumbnail) this.readFile();
   }
 
   readFile() {

--- a/src/Posting/QR/QuickReply.html
+++ b/src/Posting/QR/QuickReply.html
@@ -49,6 +49,7 @@
         <a href="javascript:;" id="qr-jpg" title="Compress to jpg">C</a>
         <a href="javascript:;" id="qr-view" title="Preview">V</a>
         <a href="javascript:;" id="qr-randomize" title="Randomize filename">R</a>
+        <a href="javascript:;" id="qr-checksum" title="Randomize checksum">R</a>
         <a href="javascript:;" id="qr-restore-name" title="Reset filename">U</a>
         <a href="javascript:;" id="qr-filerm" title="Remove file">✕</a>
         <a href="javascript:;" id="url-button" title="Post from URL">🔗︎</a>

--- a/src/config/Config.js
+++ b/src/config/Config.js
@@ -521,6 +521,11 @@ const Config = {
         'Set the filename to a random timestamp within the past year. Disabled on /f/.',
         1
       ],
+      'Randomize Checksum': [
+        false,
+        'Re-encode uploaded images to prevent matching.',
+        1
+      ],
       'Show New Thread Option in Threads': [
         true,
         'Show the option to post a new / different thread from inside a thread.',

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -1786,6 +1786,7 @@ input#qr-filename {
 #qr:not(.has-spoiler) #qr-spoiler-label,
 #file-n-submit:not(.has-file) #qr-spoiler-label,
 #file-n-submit:not(.has-file) #qr-randomize,
+#file-n-submit:not(.has-image) #qr-checksum,
 #file-n-submit:not(.has-image) #qr-jpg,
 #file-n-submit:not(.has-image):not(.has-video) #qr-view,
 #file-n-submit:not(.has-file) #qr-restore-name,


### PR DESCRIPTION
Adds support for randomizing image checksums. Useful for preventing file-matching in archives. 

Method inspired by [KurobaEX](https://github.com/K1rakishou/Kuroba-Experimental/blob/02bf52013842fcdc24ea0ee353b2e8217a5fe810/Kuroba/app/src/main/java/com/github/k1rakishou/chan/utils/MediaUtils.kt#L215). Modifies a single random pixel by an amount large enough to survive JPEG compression.

In Quick Reply, the button uses the same icon as 'Gallery' as it seemed like the best one available currently.