### PR TITLE
Add Aspect Ratio to File Info

### DIFF
--- a/src/Filtering/Filter.ts
+++ b/src/Filtering/Filter.ts
@@ -50,7 +50,7 @@ export interface FilterResults {
 };
 
 type FilterType = "postID" | "name" | "uniqueID" | "tripcode" | "capcode" | "pass" | "email" | "subject" | "comment"
-  | "flag" | "filename" | "dimensions" | "filesize" | "MD5";
+  | "flag" | "filename" | "dimensions" | "filesize" | "MD5" | "aspectratio";
 
 var Filter = {
   /**
@@ -448,7 +448,8 @@ var Filter = {
     filename(post) { return post.files.map(f => f.name); },
     dimensions(post) { return post.files.map(f => f.dimensions); },
     filesize(post) { return post.files.map(f => f.size); },
-    MD5(post) { return post.files.map(f => f.MD5); }
+    MD5(post) { return post.files.map(f => f.MD5); },
+    aspectratio(post) { return post.files.map(f => f.aspectRatio); }
   } satisfies Record<FilterType, (post: Post) => string[]>,
 
   values(key: FilterType, post: Post): string[] {
@@ -601,7 +602,8 @@ var Filter = {
         ['Filename',         'filename'],
         ['Image dimensions', 'dimensions'],
         ['Filesize',         'filesize'],
-        ['Image MD5',        'MD5']
+        ['Image MD5',        'MD5'],
+        ['Aspect Ratio',     'aspectratio']
       ] satisfies [string, FilterType][]) {
         // Add a sub entry for each filter type.
         entry.subEntries.push(Filter.menu.createSubEntry(type[0], type[1]));

--- a/src/General/Settings.tsx
+++ b/src/General/Settings.tsx
@@ -787,7 +787,8 @@ Enable it on boards.${location.hostname.split('.')[1]}.org in your browser's pri
         isImage: true,
         isVideo: false,
         isSpoiler: true,
-        tag: 'Loop'
+        tag: 'Loop',
+        aspectRatio: '16x9 (Landscape)'
       }
     };
     FileInfo.format(this.value, data, this.nextElementSibling);

--- a/src/General/Settings/Filter-select.html
+++ b/src/General/Settings/Filter-select.html
@@ -15,5 +15,6 @@
   <option value="dimensions">Image dimensions</option>
   <option value="filesize">Filesize</option>
   <option value="MD5">Image MD5</option>
+  <option value="aspectratio">Aspect Ratio</option>
   </select>
 <div></div>

--- a/src/Miscellaneous/FileInfo.tsx
+++ b/src/Miscellaneous/FileInfo.tsx
@@ -99,6 +99,7 @@ var FileInfo = {
     M() { return { innerHTML: (Math.round(this.file.sizeInBytes / 1048576 * 100) / 100) + " MB", [isEscaped]: true }; },
     r() { return { innerHTML: E(this.file.dimensions || "PDF"), [isEscaped]: true }; },
     g() { return { innerHTML: ((this.file.tag) ? ", " + E(this.file.tag) : ""), [isEscaped]: true }; },
+    a() { return { innerHTML: (this.file.aspectRatio), [isEscaped]: true }; },
     '%'() { return { innerHTML: "%", [isEscaped]: true }; }
   }
 };

--- a/src/config/Config.js
+++ b/src/config/Config.js
@@ -799,7 +799,9 @@ const Config = {
 
     filesize: '',
 
-    MD5: ''
+    MD5: '',
+
+    aspectratio: ''
   },
 
   sauces: `\


### PR DESCRIPTION
Thanks to ChatGPT, which in itself was probably based off a [comment I found on Stack Overflow in my own search](https://github.com/saxamaphone69/ss21/blob/main/sidedish.user.js#L542), I've done a rough PR that allows users to display the aspect ratio and orientation of images.

There are definitely improvements to be made:

- The `File` class has `width` and `height`, but I couldn't get it working, so I call `file.dimensions` and split it.
- The function itself is probably not written correctly or in the correct location. It could be moved to `$` where `isImage` and `isVideo` is?
- Ideally, I guess for PDFs `aspectRatio` is nothing? Currently in my poor attempt to get it working, I just gave it the value of `?`.
- The ratios are hard coded, along with the tolerance. I guess these could be user configurated, but that added complexity seems tricky (for me to add on my own).
- Perhaps `orientation` could be something different, as in its own property?
- Wrapping the results in a `span` could allow users extra configuration options, if they desire. `<span class="file-orientation file-orientation--landscape">(Landscape)</span>` opens some `:has()` and `:not()` opportunities, as does just the Filter option in general, `/16:9/;highlight:aspect-matches`.

...Looking back now that I've done it however, I'm thinking that having the aspect ratio in the file information is probably totally useless in a way. Really, it should just be a filter, where a user could then specify the aspect ratio, orientation?, and/or tolerance?. Similar to the [original 4chan X issue](https://github.com/ccd0/4chan-x/issues/2888).

If nothing else, maybe it might inspire someone else to follow on.

I'm staring at the `aspectratio(post) { return post.files.map(f => f.aspectRatio); }` part of `Filter.ts` and thinking something could probably happen there... right?