### PR TITLE
Convert a few more things into icons

### DIFF
--- a/src/General/UI.js
+++ b/src/General/UI.js
@@ -3,6 +3,7 @@ import Main from "../main/Main";
 import $ from "../platform/$";
 import $$ from "../platform/$$";
 import Header from "./Header";
+import Icon from "../Icons/icon";
 
 /*
  * decaffeinate suggestions:
@@ -275,6 +276,11 @@ var Menu = (function() {
       for (var subEntry of subEntries) {
         this.parseEntry(subEntry);
       }
+      const span = $.el('span',
+        {className: 'menu-indicator'}
+      );
+      Icon.set(span, 'caretRight');
+      $.add(el, span);
     }
   };
   Menu.initClass();

--- a/src/Icons/icon.ts
+++ b/src/Icons/icon.ts
@@ -28,7 +28,8 @@ import { svgPathData as squarePlusSvg, width as squarePlusW, height as squarePlu
 import { svgPathData as squareMinusSvg, width as squareMinusW, height as squareMinusH } from "@fa/faSquareMinus";
 import { svgPathData as playSvg, width as playW, height as playH } from "@fas/faPlay";
 import { svgPathData as stopSvg, width as stopW, height as stopH } from "@fas/faStop";
-
+import { svgPathData as arrowUpLongSvg, width as arrowUpLongW, height as arrowUpLongH } from "@fas/faArrowUpLong";
+import { svgPathData as arrowDownLongSvg, width as arrowDownLongW, height as arrowDownLongH } from "@fas/faArrowDownLong";
 
 const toSvg = (svgPathData: string, width: string | number, height: string | number) => {
   return `<svg xmlns="http://www.w3.org/2000/svg" class="icon" viewBox="0 0 ${width} ${height}">` +
@@ -63,7 +64,9 @@ const icons = {
    squarePlus:      toSvg(squarePlusSvg, squarePlusW, squarePlusH),
    squareMinus:     toSvg(squareMinusSvg, squareMinusW, squareMinusH),
    play:            toSvg(playSvg, playW, playH),
-   stop:            toSvg(stopSvg, stopW, stopH)
+   stop:            toSvg(stopSvg, stopW, stopH),
+   arrowUpLong:     toSvg(arrowUpLongSvg, arrowUpLongW, arrowUpLongH),
+   arrowDownLong:   toSvg(arrowDownLongSvg, arrowDownLongW, arrowDownLongH)
 } as const;
 
 var Icon = {

--- a/src/Miscellaneous/Nav.js
+++ b/src/Miscellaneous/Nav.js
@@ -3,6 +3,7 @@ import Header from "../General/Header";
 import { g, Conf, d, doc } from "../globals/globals";
 import $ from "../platform/$";
 import $$ from "../platform/$$";
+import Icon from "../Icons/icon";
 
 /*
  * decaffeinate suggestions:
@@ -26,14 +27,19 @@ var Nav = {
       {id: 'navlinks'});
     const prev = $.el('a', {
       textContent: '▲',
+      className: 'navlinks-navlink navlink-prev',
       href: 'javascript:;'
     }
     );
     const next = $.el('a', {
       textContent: '▼',
+      className: 'navlinks-navlink navlink-next',
       href: 'javascript:;'
     }
     );
+
+    Icon.set(prev, 'arrowUpLong');
+    Icon.set(next, 'arrowDownLong');
 
     $.on(prev, 'click', this.prev);
     $.on(next, 'click', this.next);

--- a/src/Miscellaneous/PSAHiding.js
+++ b/src/Miscellaneous/PSAHiding.js
@@ -1,6 +1,7 @@
 import Header from "../General/Header";
 import { Conf, doc, g } from "../globals/globals";
 import $ from "../platform/$";
+import Icon from "../Icons/icon";
 /*
  * decaffeinate suggestions:
  * DS102: Remove unnecessary code created because of implicit returns
@@ -45,6 +46,7 @@ var PSAHiding = {
       textContent: '➖︎',
     }
     ));
+    Icon.set(btn, 'squareMinus');
     $.on(btn, 'click', PSAHiding.toggle);
     if (psa.firstChild?.tagName === 'HR') {
       $.after(psa.firstChild, btn);

--- a/src/Miscellaneous/PostJumper.js
+++ b/src/Miscellaneous/PostJumper.js
@@ -2,6 +2,7 @@ import Callbacks from "../classes/Callbacks";
 import { Conf, g, E } from "../globals/globals";
 import $ from "../platform/$";
 import $$ from "../platform/$$";
+import Icon from "../Icons/icon";
 
 /*
  * decaffeinate suggestions:
@@ -13,6 +14,8 @@ var PostJumper = {
     if (!Conf['Unique ID and Capcode Navigation'] || !['index', 'thread'].includes(g.VIEW)) { return; }
 
     this.buttons = this.makeButtons();
+    Icon.set(this.buttons.firstChild, 'arrowUpLong');
+    Icon.set(this.buttons.lastChild, 'arrowDownLong');
 
     return Callbacks.Post.push({
       name: 'Post Jumper',

--- a/src/Posting/QR.ts
+++ b/src/Posting/QR.ts
@@ -897,6 +897,7 @@ var QR = {
     Icon.set(nodes.view, 'eye');
     Icon.set(nodes.restoreNameButton, 'undo');
     Icon.set(nodes.splitPost, 'scissors');
+    Icon.set(nodes.fileRM, 'xmark');
     Icon.set(nodes.close, 'xmark');
     Icon.set(nodes.dumpButton, 'squarePlus');
     Icon.set(nodes.addPost, 'plus');

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -1360,7 +1360,6 @@ input[name="Default Volume"] {
 
 /* Index/Reply Navigation */
 #navlinks {
-  font-size: 16px;
   top: 25px;
   right: 10px;
 }
@@ -1948,11 +1947,10 @@ a:only-of-type > .remove {
 #file-n-submit .row.space {
   justify-content: space-between;
 }
-#file-n-submit a {
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  padding: 1px 3px 0 3px;
+#file-n-submit > .row.space > .row {
+  align-items: center;
+  gap: 6px;
+  padding: 0 3px;
 }
 
 /* Menu */
@@ -1986,9 +1984,6 @@ a:only-of-type > .remove {
   text-shadow: none;
   font-size: 10pt;
 }
-.left>.entry.has-submenu {
-  padding-right: 17px !important;
-}
 .entry input[type="checkbox"],
 .entry input[type="radio"] {
   margin: 0px;
@@ -1998,7 +1993,8 @@ a:only-of-type > .remove {
 .entry input[type="number"] {
   width: 4.5em;
 }
-.entry.has-shortcut-text {
+.entry.has-shortcut-text,
+.entry.has-submenu {
   display: flex;
   justify-content: space-between;
   align-items: center;
@@ -2008,19 +2004,13 @@ a:only-of-type > .remove {
   font-size: 70%;
   margin-left: 5px;
 }
-.has-submenu::after {
-  content: "";
-  border-left: .5em solid;
-  border-top: .3em solid transparent;
-  border-bottom: .3em solid transparent;
-  display: inline-block;
-  margin: .3em;
-  position: absolute;
-  right: 3px;
+.menu-indicator {
+  pointer-events: none;
+  position: relative;
+  right: -7px;
 }
-.left .has-submenu::after {
-  border-left: 0;
-  border-right: .5em solid;
+.left .menu-indicator > .icon {
+  transform: rotoate(180deg);
 }
 .submenu {
   display: none;
@@ -2269,12 +2259,6 @@ a:only-of-type > .remove {
 }
 .invisible {
   font-size: 0;
-}
-
-/* PostJumper */
-.postJumper > .prev,
-.postJumper > .next {
-  font-size: 120%;
 }
 
 /* PSA */

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -2010,7 +2010,7 @@ a:only-of-type > .remove {
   right: -7px;
 }
 .left .menu-indicator > .icon {
-  transform: rotoate(180deg);
+  transform: rotate(180deg);
 }
 .submenu {
   display: none;


### PR DESCRIPTION
- Turns the submenu indicator in the menu into an icon (along with CSS changes)
- Turns the `minus` from the hide announcement button into an icon
- Turns the Thread/Reply Navigation, and the Post Jumper into an arrow up and down (when left at `16px` and `120%` they seemed oversized)
- Turns the 'Remove file' icon in the QR into `xmark` too (while there, use `gap` to spread icons out)