### PR TITLE
Add image rotation controls

### DIFF
--- a/src/General/Settings/Advanced.html
+++ b/src/General/Settings/Advanced.html
@@ -161,6 +161,19 @@
 </fieldset>
 
 <fieldset>
+  <legend>Image Media Controls <span class="warning" data-feature="Image Media Controls">is disabled.</span></legend>
+  <label>Media Controls Position
+    <select name="imageMediaControlsPosition">
+      <option value="top-left">Top left</option>
+      <option value="top-right">Top right</option>
+      <option value="bottom-left">Bottom left</option>
+      <option value="bottom-right">Bottom right</option>
+    </select>
+  </label>
+  <span class="favicon-preview"></span>
+</fieldset>
+
+<fieldset>
   <legend>Thread Updater <span class="warning" data-feature="Thread Updater">is disabled.</span></legend>
   <div>
     Interval: <input type="number" name="Interval" class="field" min="1"> seconds

--- a/src/Icons/icon.ts
+++ b/src/Icons/icon.ts
@@ -13,6 +13,8 @@ import { svgPathData as clockSvg, width as clockW, height as clockH } from "@fa/
 import { svgPathData as linkSvg, width as linkW, height as linkH } from "@fas/faLink";
 import { svgPathData as shuffleSvg, width as shuffleW, height as shuffleH } from "@fas/faShuffle";
 import { svgPathData as undoSvg, width as undoW, height as undoH } from "@fas/faRotateLeft";
+import { svgPathData as rotateLeftSvg, width as rotateLeftW, height as rotateLeftH } from "@fas/faRotateLeft";
+import { svgPathData as rotateRightSvg, width as rotateRightW, height as rotateRightH } from "@fas/faRotateRight";
 import { svgPathData as downloadSvg, width as downloadW, height as downloadH } from "@fas/faDownload";
 import { svgPathData as bookOpenSvg, width as bookOpenW, height as bookOpenH } from "@fas/faBookOpen";
 import { svgPathData as shrinkSvg, width as shrinkW, height as shrinkH } from "@fas/faDownLeftAndUpRightToCenter";
@@ -50,6 +52,8 @@ const icons = {
    clock:           toSvg(clockSvg, clockW, clockH),
    shuffle:         toSvg(shuffleSvg, shuffleW, shuffleH),
    undo:            toSvg(undoSvg, undoW, undoH),
+   rotateLeft:      toSvg(rotateLeftSvg, rotateLeftW, rotateLeftH),
+   rotateRight:     toSvg(rotateRightSvg, rotateRightW, rotateRightH),
    download:        toSvg(downloadSvg, downloadW, downloadH),
    bookOpen:        toSvg(bookOpenSvg, bookOpenW, bookOpenH),
    shrink:          toSvg(shrinkSvg, shrinkW, shrinkH),

--- a/src/Images/ImageExpand.ts
+++ b/src/Images/ImageExpand.ts
@@ -8,6 +8,7 @@ import Nav from "../Miscellaneous/Nav";
 import $ from "../platform/$";
 import { SECOND } from "../platform/helpers";
 import ImageCommon from "./ImageCommon";
+import MediaControls from "./ImageMediaControls/MediaControls"
 import Volume from "./Volume";
 import Audio from "./Audio";
 import type { default as Post, PostClone } from "../classes/Post";
@@ -220,6 +221,11 @@ var ImageExpand = {
         delete file.audioSlider;
       }
     }
+
+    if (file.imageMediaControls) {
+      $.rm(file.imageMediaControls);
+      delete file.imageMediaControls;
+    }
   },
 
   expand(post: Post, src?: string) {
@@ -292,6 +298,74 @@ var ImageExpand = {
         $.after(el, audioEl);
         file.audio = audioEl;
       }
+    }
+
+    if (Conf['Image Media Controls']) {
+      const controls = $.el('div', MediaControls());
+      const [y, x] = Conf['imageMediaControlsPosition'].split('-');
+      [...controls.childNodes][0].classList.add(`media-controls-${x}`, `media-controls-${y}`);
+      const container = $.el('div', {className: 'media-controls-container'});
+      const wrapper = $.el('div', {className: 'media-controls-wrapper'});
+      file.imageMediaControls = container;
+      $.add(container, [...controls.childNodes]);
+      $.add(wrapper, el);
+      $.add(container, wrapper);
+      $.prepend(thumbLink, container);
+
+      const totalRotationStates = 4;
+      let currentRotationState = 0;
+
+
+      const { width } = el.getBoundingClientRect();
+      const initialImageContentWidth = width;
+
+      el.style.maxWidth = `${initialImageContentWidth}px`;
+      el.style.maxHeight = '';
+
+      function positiveModulo(a: number, n: number): number {
+        return ((a % n) + n) % n;
+      }
+
+
+      const compensateTransformedSize = () => {
+        const rotationState = positiveModulo(currentRotationState, totalRotationStates);
+        const { width, height } = wrapper.getBoundingClientRect();
+
+        if (rotationState === 1 || rotationState === 3) {
+          el.style.maxHeight = `${initialImageContentWidth}px`;
+        } else {
+          el.style.maxHeight = ''; 
+        }
+
+        Object.assign(container.style, { width: `${width}px`, height: `${height}px` });
+      };
+
+      const compensateTransformedSizeObserver = new ResizeObserver(
+        compensateTransformedSize,
+      );
+
+      function updateRotation() {
+        compensateTransformedSizeObserver.observe(wrapper);
+        wrapper.setAttribute('rotation', String(positiveModulo(currentRotationState, totalRotationStates)));
+        compensateTransformedSize(); 
+      }
+
+      const leftBtn = thumbLink.querySelector('[data-action="rotateLeft"]');
+      const rightBtn = thumbLink.querySelector('[data-action="rotateRight"]');
+
+      $.on(leftBtn, 'click', (e) => {
+        e.preventDefault();
+        e.stopPropagation();
+        currentRotationState--;
+        updateRotation();
+      });
+
+      $.on(rightBtn, 'click', (e) => {
+        e.preventDefault();
+        e.stopPropagation();
+        currentRotationState++;
+        updateRotation();
+      });
     }
   },
 

--- a/src/Images/ImageMediaControls/MediaControls.tsx
+++ b/src/Images/ImageMediaControls/MediaControls.tsx
@@ -1,0 +1,12 @@
+import h, { EscapedHtml } from "../../globals/jsx";
+import $ from "../../platform/$";
+import Icon from "../../Icons/icon";
+
+export default function MediaControls(): EscapedHtml {
+  return (
+    <div class='media-controls'>
+      <button data-action="rotateLeft">{Icon.raw('rotateLeft')}</button>
+      <button data-action="rotateRight">{Icon.raw('rotateRight')}</button>
+    </div>
+  );
+}

--- a/src/classes/Post.ts
+++ b/src/classes/Post.ts
@@ -29,6 +29,7 @@ export interface File {
   fullImage?:  HTMLImageElement | HTMLVideoElement,
   audio?:      HTMLAudioElement,
   audioSlider?:HTMLSpanElement,
+  imageMediaControls?: HTMLDivElement,
   wasPlaying?: boolean,
   dimensions?: string,
   height?:     string,

--- a/src/config/Config.js
+++ b/src/config/Config.js
@@ -246,6 +246,10 @@ const Config = {
         true,
         'Expand images / videos.'
       ],
+      'Image Media Controls': [
+        true,
+        'Show additional media controls when hovering over expanded images.'
+      ],
       'Image Hover': [
         true,
         'Show full image / video on mouseover.'
@@ -687,6 +691,8 @@ const Config = {
       'Advance to next post when contracting an expanded image.'
     ]
   },
+
+  imageMediaControlsPosition: 'top-left',
 
   gallery: {
     'Hide Thumbnails': [

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -1253,7 +1253,7 @@ textarea.copy-text-element {
   display: none;
   cursor: pointer;
 }
-.expanded-image > .post > .file > .fileThumb > .full-image {
+.expanded-image > .post > .file > .fileThumb .full-image {
   display: inline;
 }
 .expanded-image > .post > .file > .fileThumb > audio {
@@ -2262,4 +2262,83 @@ div.post {
 
 .scroll-marker-container {
   display: contents;
+}
+
+/* Media Controls */
+.media-controls-container {
+  position: relative;
+}
+
+.media-controls-wrapper {
+  display: table;
+}
+
+.media-controls-wrapper[rotation] {
+  transform-origin: top left;
+}
+
+.media-controls-wrapper[rotation="0"] {
+	transform: initial;
+}
+
+.media-controls-wrapper[rotation="1"] {
+	transform: rotate(90deg) translateY(-100%);
+}
+
+.media-controls-wrapper[rotation="2"] {
+	transform: rotate(180deg) translate(-100%, -100%);
+}
+
+.media-controls-wrapper[rotation="3"] {
+	transform: rotate(270deg) translateX(-100%);
+}
+
+.fileThumb:hover > .media-controls-container > .media-controls {
+  opacity: 1;
+}
+
+.media-controls {
+  position: absolute;
+  opacity: 0;
+  z-index: 1;
+  background: rgba(0, 0, 0, 0.3);
+}
+
+.media-controls-top {
+  top: 10px;
+}
+
+.media-controls-left {
+  left: 10px;
+}
+
+.media-controls-bottom {
+  bottom: 10px;
+}
+
+.media-controls-right {
+  right: 10px;
+}
+
+.media-controls > button {
+  background: transparent;
+  margin: 0;
+  border-style: none;
+  border-color: initial;
+  line-height: 0;
+  filter: saturate(0);
+  cursor: pointer;
+  padding: 6px;
+}
+
+.media-controls > button > svg {
+  color: rgb(238, 238, 238);
+}
+
+.media-controls > button:hover > svg {
+  color: rgb(185, 185, 185);
+}
+
+.expanded-image > .post > .file > .fileThumb .media-controls-wrapper > .full-image {
+  width: inherit;
 }


### PR DESCRIPTION
Implements image rotation on hover for images displayed in 4chan-xt, fulfilling feature request https://github.com/TuxedoTako/4chan-xt/issues/181. 

I briefly tested the script in Firefox and Chrome using Tampermonkey, and it works without any issues. Please let me know if I should change anything in the code.

<details>
	<summary>Preview</summary>
	<div>
		<img src="https://github.com/user-attachments/assets/4c36aea3-811a-4b7d-992e-d230ba16cbb2">
	</div>
	<div>
		<img src="https://github.com/user-attachments/assets/a99a7313-7aea-4a2a-a2d8-2873a642d303">
	</div>
</details>